### PR TITLE
Added abstact to pod

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for perl module Dancer::Template::Caml
 
+0.11 2014-03-
+
+ - Added abstract (=head1 NAME) section to pod
+
 0.10 2012-01-25
 
  - Made path manipulations portable

--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for perl module Dancer::Template::Caml
 0.11 2014-03-
 
  - Added abstract (=head1 NAME) section to pod
+ - Made the repository a hyperlink in the pod
 
 0.10 2012-01-25
 

--- a/lib/Dancer/Template/Caml.pm
+++ b/lib/Dancer/Template/Caml.pm
@@ -40,6 +40,10 @@ sub render {
 
 1;
 
+=head1 NAME
+
+Dancer::Template::Caml - use Template::Caml for templating with Dancer
+
 =head1 DESCRIPTION
 
 This class is an interface between Dancer's template engine abstraction layer

--- a/lib/Dancer/Template/Caml.pm
+++ b/lib/Dancer/Template/Caml.pm
@@ -79,7 +79,7 @@ L<Dancer>, L<Text::Caml>
 
 =head2 Repository
 
-    http://github.com/vti/dancer-template-caml
+L<http://github.com/vti/dancer-template-caml>
 
 =head1 AUTHOR
 


### PR DESCRIPTION
Hi,

I've added an abstract section to your pod. Various tools (like MetaCPAN and search.cpan.org) expect to find an abstract in the pod. Because it doesn't find one, MetaCPAN presents your module a bit differently from most modules.

Cheers,
Neil
